### PR TITLE
La vida sigue sin bajar

### DIFF
--- a/api-superheroes/package-lock.json
+++ b/api-superheroes/package-lock.json
@@ -15,7 +15,7 @@
         "express-validator": "^7.2.1",
         "fs-extra": "^11.3.0",
         "jsonwebtoken": "^9.0.0",
-        "mongoose": "^8.0.0"
+        "mongoose": "^8.17.0"
       }
     },
     "node_modules/@mongodb-js/saslprep": {
@@ -715,9 +715,9 @@
       }
     },
     "node_modules/mongodb": {
-      "version": "6.17.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.17.0.tgz",
-      "integrity": "sha512-neerUzg/8U26cgruLysKEjJvoNSXhyID3RvzvdcpsIi2COYM3FS3o9nlH7fxFtefTb942dX3W9i37oPfCVj4wA==",
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.18.0.tgz",
+      "integrity": "sha512-fO5ttN9VC8P0F5fqtQmclAkgXZxbIkYRTUi1j8JO6IYwvamkhtYDilJr35jOPELR49zqCJgXZWwCtW7B+TM8vQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mongodb-js/saslprep": "^1.1.9",
@@ -771,14 +771,14 @@
       }
     },
     "node_modules/mongoose": {
-      "version": "8.16.4",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.16.4.tgz",
-      "integrity": "sha512-jslgdQ8pY2vcNSKPv3Dbi5ogo/NT8zcvf6kPDyD8Sdsjsa1at3AFAF0F5PT+jySPGSPbvlNaQ49nT9h+Kx2UDA==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.17.0.tgz",
+      "integrity": "sha512-mxW6TBPHViORfNYOFXCVOnT4d5aRr+CgDxTs1ViYXfuHzNpkelgJQrQa+Lz6hofoEQISnKlXv1L3ZnHyJRkhfA==",
       "license": "MIT",
       "dependencies": {
         "bson": "^6.10.4",
         "kareem": "2.6.3",
-        "mongodb": "~6.17.0",
+        "mongodb": "~6.18.0",
         "mpath": "0.9.0",
         "mquery": "5.0.0",
         "ms": "2.1.3",

--- a/api-superheroes/package.json
+++ b/api-superheroes/package.json
@@ -19,6 +19,6 @@
     "express-validator": "^7.2.1",
     "fs-extra": "^11.3.0",
     "jsonwebtoken": "^9.0.0",
-    "mongoose": "^8.0.0"
+    "mongoose": "^8.17.0"
   }
 }

--- a/api-superheroes/services/petService.js
+++ b/api-superheroes/services/petService.js
@@ -227,15 +227,19 @@ async function alimentar(id) {
   if (pet.hambre <= 0) {
     pet.enfermedad = 'Gripa';
     pet.felicidad = Math.max(0, pet.felicidad - 10);
+    pet.vida = Math.max(0, pet.vida - 10); // Descuento inmediato de vida
     pet.historial.push('Se enfermó de Gripa por sobrealimentación (llena)');
     pet.enfermoDesde = Date.now();
     pet.recuperandoDesde = null;
+    console.log('Descuento inmediato por Gripa: vida -10, felicidad -10');
   } else if (pet.hambre >= 100) {
     pet.enfermedad = 'Gripa';
     pet.felicidad = Math.max(0, pet.felicidad - 10);
+    pet.vida = Math.max(0, pet.vida - 10); // Descuento inmediato de vida
     pet.historial.push('Se enfermó de Gripa por sobrealimentación');
     pet.enfermoDesde = Date.now();
     pet.recuperandoDesde = null;
+    console.log('Descuento inmediato por Gripa: vida -10, felicidad -10');
   } else {
     pet.hambre = Math.max(0, pet.hambre - 30);
     pet.felicidad = Math.min(100, pet.felicidad + 5);
@@ -284,9 +288,11 @@ async function pasear(id) {
   if (pet.hambre > 100) {
     pet.enfermedad = 'Sarpullido';
     pet.felicidad = Math.max(0, pet.felicidad - 5);
+    pet.vida = Math.max(0, pet.vida - 5); // Descuento inmediato de vida
     pet.historial.push('Se enfermó de Sarpullido por hambre excesiva');
     pet.enfermoDesde = Date.now();
     pet.recuperandoDesde = null;
+    console.log('Descuento inmediato por Sarpullido: vida -5, felicidad -5');
   }
   
   // Solo marcar como muerta si la felicidad llega a 0 después de la acción
@@ -322,9 +328,11 @@ async function jugar(id) {
   if (pet.hambre > 100) {
     pet.enfermedad = 'Piel de Salchicha';
     pet.felicidad = Math.max(0, pet.felicidad - 15);
+    pet.vida = Math.max(0, pet.vida - 15); // Descuento inmediato de vida
     pet.historial.push('Se enfermó de Piel de Salchicha por hambre excesiva');
     pet.enfermoDesde = Date.now();
     pet.recuperandoDesde = null;
+    console.log('Descuento inmediato por Piel de Salchicha: vida -15, felicidad -15');
   }
   
   // Solo marcar como muerta si la felicidad llega a 0 después de la acción


### PR DESCRIPTION
Apply immediate health and happiness penalties when a pet gets sick. Previously, the decay only applied after a delay or when `getEstado` was called, leading to no immediate visual feedback.

---
<a href="https://cursor.com/background-agent?bcId=bc-be3a33f4-a260-4c9c-a13b-f25a795c947c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-be3a33f4-a260-4c9c-a13b-f25a795c947c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>